### PR TITLE
Added channel config support to RealtimeClient

### DIFF
--- a/src/Api/Clients/ProductClient.cs
+++ b/src/Api/Clients/ProductClient.cs
@@ -85,12 +85,12 @@ namespace Boukenken.Gdax
 			var CandleData =  await this.GetResponseAsync<JArray>(
 					new ApiRequest(HttpMethod.Get, $"/products/{i_product_id}/candles?start={i_start.ToString("yyyy-MM-ddTHH:mm:00.00000Z")}&end={i_end.ToString("yyyy-MM-ddTHH:mm:00.00000Z")}&granularity={i_granularity.TotalSeconds}")
 					);
-			Candle c = new Candle();
 			List<Candle> cl = new List<Candle>();
 			JArray x = CandleData.Value;
 			int index = x.Count;
 			while (index-- > 0)
 			{
+                var c = new Candle();
 				c.time = (long)x[index][0];
 				c.low = (decimal)x[index][1];
 				c.high = (decimal)x[index][2];
@@ -98,6 +98,7 @@ namespace Boukenken.Gdax
 				c.close = (decimal)x[index][4];
 				c.volume = (decimal)x[index][5];
 				cl.Add(c);
+                c = null;
 			}
 
 			return cl;

--- a/src/gdax.netcore.csproj
+++ b/src/gdax.netcore.csproj
@@ -3,22 +3,17 @@
     <TargetFramework>netstandard1.6</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json">
-      <Version>10.0.2</Version>
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.2">
     </PackageReference>
-    <PackageReference Include="System.Collections">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Collections" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Linq">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Linq" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Net.Http">
-      <Version>4.3.1</Version>
+    <PackageReference Include="System.Net.Http" Version="4.3.1">
     </PackageReference>
     <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.0" />
     <PackageReference Include="System.Reactive" Version="3.1.1" />
-    <PackageReference Include="System.Runtime">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Runtime" Version="4.3.0">
     </PackageReference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Adds support to configure the channels in the constructor.

example of usage:
`var client = new RealtimeClient(new Uri("wss://ws-feed.gdax.com"), new String[] { "BTC-EUR" },
                                            new[]{
                                                new {
                                                        name = "ticker",
                                                        product_ids = new String[] { "BTC-EUR" }
                                                }
                                            });`